### PR TITLE
Feat(Detect): Activate Extension In Adonis Project

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
 	],
 	"activationEvents": [
 		"onLanguage:edge",
-		"onLanguage:javascript",
-		"onLanguage:typescript",
-		"workspaceContains:ace"
+		"workspaceContains:**/.adonisrc.json"
 	],
 	"main": "./out/extension.js",
 	"contributes": {


### PR DESCRIPTION
Resolves #5.

This ensures that the extension is only triggered in:
- An `adonis` project, or
- Upon the existence of an `edge` template file.